### PR TITLE
Fix Linux distros not appearing

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -82,3 +82,5 @@ let linuxlist = [
 		"platform": "x64, x32, arm64, pi"
 	}
 ]
+
+export default linuxlist;


### PR DESCRIPTION
Fixes Linux distros not appearing, mentioned [here](https://scratch.mit.edu/discuss/post/6044758/).
Not tested, should work. Only merge after testing.